### PR TITLE
[BUGFIX] Avoid 'Undefined array key "uid" '

### DIFF
--- a/Classes/Task/ImportUsers.php
+++ b/Classes/Task/ImportUsers.php
@@ -173,7 +173,7 @@ class ImportUsers extends \TYPO3\CMS\Scheduler\Task\AbstractTask
 
                             // Import the user using information from LDAP
                             $restoreBehaviour = $this->restoredUsersHandling;
-                            if (in_array($user['uid'], $disabledOrDeletedUserUids, true)) {
+                            if (in_array($user['uid'] ?? 0, $disabledOrDeletedUserUids, true)) {
                                 // We disabled this user ourselves
                                 if ($this->missingUsersHandling === 'disable') {
                                     if ($restoreBehaviour === 'nothing') {


### PR DESCRIPTION
In the case of a new user (and the usual case that the UID is *not* set via LDAP mapping), 'uid' is not set. This caused an 'Undefined array key "uid"' warning.